### PR TITLE
Update bug report template to include reproduction info

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -10,6 +10,9 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
+**Reproduced with**
+Describe your WordPress, theme and plugins version activated to reproduce the issue
+
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
@@ -19,12 +22,6 @@ Steps to reproduce the behavior:
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
-
-**Environment (please complete the following information):**
- - Device: [e.g. Desktop, iPhone...]
- - OS: [e.g. Unbuntu, iOS...]
- - Browser [e.g. Chrome, Safari...]
- - Version [e.g. 22]
 
 **Additional context, screenshots**
 Add any other context about the problem here.


### PR DESCRIPTION
Added a section for reproducing the bug with WordPress versions and removed the environment details section.